### PR TITLE
Adding loki logs

### DIFF
--- a/docs/node-mixin/config.libsonnet
+++ b/docs/node-mixin/config.libsonnet
@@ -59,5 +59,7 @@
 
     dashboardNamePrefix: 'Node Exporter / ',
     dashboardTags: ['node-exporter-mixin'],
+
+    enableLokiLogs: false,
   },
 }

--- a/docs/node-mixin/dashboards/node.libsonnet
+++ b/docs/node-mixin/dashboards/node.libsonnet
@@ -262,18 +262,19 @@ local prometheusDatasourceTemplate = {
     timezone='utc',
     refresh='30s',
     graphTooltip='shared_crosshair'
-  ),
+  )
+  .addTemplate(prometheusDatasourceTemplate) 
+  .addRow($._cpuRow)
+  .addRow($._memoryRow)
+  .addRow($._diskRow)
+  .addRow($._networkRow),
+  
    
   grafanaDashboards+:: 
     if !$._config.enableLokiLogs then {
       'nodes.json':
         $._NodeDashboard
-        .addTemplate(prometheusDatasourceTemplate)
         .addTemplate($._instanceTemplate)
-        .addRow($._cpuRow)
-        .addRow($._memoryRow)
-        .addRow($._diskRow)
-        .addRow($._networkRow), 
     }
     else {
       'nodes.json':
@@ -385,15 +386,10 @@ local prometheusDatasourceTemplate = {
           .addPanel(journalstdout);
 
         $._NodeDashboard
-        .addTemplate(prometheusDatasourceTemplate)
         .addTemplate(lokiDatasourceTemplate)
         .addTemplate(jobTemplate)      
         .addTemplate($._instanceTemplate)
         .addTemplate(unitTemplate)
-        .addRow($._cpuRow)
-        .addRow($._memoryRow)
-        .addRow($._diskRow)
-        .addRow($._networkRow)
         .addRow(lokiDirectLogRow)
         .addRow(lokiJournalLogRow),             
     }, 

--- a/docs/node-mixin/dashboards/node.libsonnet
+++ b/docs/node-mixin/dashboards/node.libsonnet
@@ -90,8 +90,6 @@ local prometheusDatasourceTemplate = {
     .addTarget(prometheus.target('node_memory_Cached_bytes{%(nodeExporterSelector)s, instance="$instance"}' % $._config, legendFormat='memory cached'))
     .addTarget(prometheus.target('node_memory_MemFree_bytes{%(nodeExporterSelector)s, instance="$instance"}' % $._config, legendFormat='memory free')),
 
-  // TODO: It would be nicer to have a gauge that gets a 0-1 range and displays it as a percentage 0%-100%.
-  // This needs to be added upstream in the promgrafonnet library and then changed here.
   // NOTE: avg() is used to circumvent a label change caused by a node_exporter rollout.
   _memoryGaugePanel :: 
     gaugePanel.new(

--- a/docs/node-mixin/dashboards/node.libsonnet
+++ b/docs/node-mixin/dashboards/node.libsonnet
@@ -11,14 +11,14 @@ local logPanel = grafana.logPanel;
 
 local c = import '../config.libsonnet';
 
-local datasourceTemplate = {
+local prometheusDatasourceTemplate = {
   current: {
     text: 'Prometheus',
     value: 'Prometheus',
   },
   hide: 0,
   label: 'Data Source',
-  name: 'datasource',
+  name: 'prometheus_datasource',
   options: [],
   query: 'prometheus',
   refresh: 1,
@@ -30,7 +30,7 @@ local datasourceTemplate = {
   _idleCPUPanel ::
     graphPanel.new(
       'CPU Usage',
-      datasource='$datasource',
+      datasource='$prometheus_datasource',
       span=6,
       format='percentunit',
       max=1,
@@ -52,7 +52,7 @@ local datasourceTemplate = {
   _systemLoadPanel ::
     graphPanel.new(
       'Load Average',
-      datasource='$datasource',
+      datasource='$prometheus_datasource',
       span=6,
       format='short',
       min=0,
@@ -66,7 +66,7 @@ local datasourceTemplate = {
   _memoryGraphPanel ::
     graphPanel.new(
       'Memory Usage',
-      datasource='$datasource',
+      datasource='$prometheus_datasource',
       span=9,
       format='bytes',
       stack=true,
@@ -109,7 +109,7 @@ local datasourceTemplate = {
   _diskIOPanel ::
     graphPanel.new(
       'Disk I/O',
-      datasource='$datasource',
+      datasource='$prometheus_datasource',
       span=6,
       min=0,
       fill=0,
@@ -148,7 +148,7 @@ local datasourceTemplate = {
   _diskSpaceUsagePanel ::
     graphPanel.new(
       'Disk Space Usage',
-      datasource='$datasource',
+      datasource='$prometheus_datasource',
       span=6,
       format='bytes',
       min=0,
@@ -193,7 +193,7 @@ local datasourceTemplate = {
   _networkReceivedPanel ::
     graphPanel.new(
       'Network Received',
-      datasource='$datasource',
+      datasource='$prometheus_datasource',
       span=6,
       format='bytes',
       min=0,
@@ -207,7 +207,7 @@ local datasourceTemplate = {
   _networkTransmittedPanel ::
     graphPanel.new(
       'Network Transmitted',
-      datasource='$datasource',
+      datasource='$prometheus_datasource',
       span=6,
       format='bytes',
       min=0,
@@ -240,9 +240,10 @@ local datasourceTemplate = {
 
   _instanceTemplate:: template.new(
     'instance',
-    '$datasource',
+    '$prometheus_datasource',
     'label_values(node_exporter_build_info{%(nodeExporterSelector)s}, instance)' % $._config,
     refresh='time',
+    label='Instance',
   ),
 
   _NodeDashboard:: dashboard.new(
@@ -258,7 +259,7 @@ local datasourceTemplate = {
     if !$._config.enableLokiLogs then {
       'nodes.json':
         $._NodeDashboard
-        .addTemplate(datasourceTemplate)
+        .addTemplate(prometheusDatasourceTemplate)
         .addTemplate($._instanceTemplate)
         .addRow($._cpuRow)
         .addRow($._memoryRow)
@@ -273,12 +274,12 @@ local datasourceTemplate = {
           {
             text: 'Loki',
             value: 'Loki',
-          },          
+          },                    
+          name: 'loki_datasource',
           label: 'Loki Data Source',
-          name: 'logs_datasource',
           options: [],
           query: 'loki',
-          hide: if $._config.enableLokiLogs then '' else '2',
+          hide: 0,
           refresh: 1,
           regex: '',
           type: 'datasource',         
@@ -286,16 +287,28 @@ local datasourceTemplate = {
 
         local jobTemplate = template.new(
           'job',
-          '$datasource',
+          '$prometheus_datasource',
           'label_values(node_exporter_build_info, job)',
-          hide= if $._config.enableLokiLogs then '' else '2',
+          hide= 0,
+          label='Job',
           refresh='time',          
+        );
+
+        local unitTemplate = template.new(
+          'unit',
+          '$loki_datasource',
+          'label_values(unit)',
+          label= 'Systemd Unit',
+          refresh='time',
+          includeAll=true,
+          multi=true,
+          allValues='.+',
         );
 
         local syslog = 
         logPanel.new(
           'syslog Errors',
-          datasource='$logs_datasource',
+          datasource='$loki_datasource',
         )
         .addTarget(
           loki.target('{filename=~"/var/log/syslog*|/var/log/messages*", %(nodeExporterSelector)s, instance=~"$instance"} |~".+(?i)error(?-i).+"' % $._config)
@@ -304,7 +317,7 @@ local datasourceTemplate = {
         local authlog = 
           logPanel.new(
             'authlog',
-            datasource='$logs_datasource',
+            datasource='$loki_datasource',
           )
           .addTarget(
             loki.target('{filename=~"/var/log/auth.log|/var/log/secure", %(nodeExporterSelector)s, instance=~"$instance"}' % $._config)
@@ -313,7 +326,7 @@ local datasourceTemplate = {
         local kernellog = 
           logPanel.new(
             'Kernel logs',
-            datasource='$logs_datasource',
+            datasource='$loki_datasource',
           )
           .addTarget(
             loki.target('{filename=~"/var/log/kern.log*", %(nodeExporterSelector)s, instance=~"$instance"}' % $._config)
@@ -322,7 +335,7 @@ local datasourceTemplate = {
         local journalsyslog = 
           logPanel.new(
             'Journal syslogs',
-            datasource='$logs_datasource',
+            datasource='$loki_datasource',
           )
           .addTarget(
             loki.target('{transport="syslog", %(nodeExporterSelector)s, instance=~"$instance"}' % $._config)
@@ -331,7 +344,7 @@ local datasourceTemplate = {
         local journalkernel = 
           logPanel.new(
             'Journal Kernel logs',
-            datasource='$logs_datasource',
+            datasource='$loki_datasource',
           )
           .addTarget(
             loki.target('{transport="kernel", %(nodeExporterSelector)s, instance=~"$instance"}' % $._config)
@@ -340,7 +353,7 @@ local datasourceTemplate = {
         local journalstdout = 
           logPanel.new(
             'Journal stdout Errors',
-            datasource='$logs_datasource',
+            datasource='$loki_datasource',
           )
           .addTarget(
             loki.target('{transport="stdout", %(nodeExporterSelector)s, instance=~"$instance", unit=~"$unit"} |~".+(?i)error(?-i).+"' % $._config)
@@ -363,10 +376,11 @@ local datasourceTemplate = {
           .addPanel(journalstdout);
 
         $._NodeDashboard
-        .addTemplate(datasourceTemplate)
+        .addTemplate(prometheusDatasourceTemplate)
         .addTemplate(lokiDatasourceTemplate)
         .addTemplate(jobTemplate)      
         .addTemplate($._instanceTemplate)
+        .addTemplate(unitTemplate)
         .addRow($._cpuRow)
         .addRow($._memoryRow)
         .addRow($._diskRow)

--- a/docs/node-mixin/dashboards/node.libsonnet
+++ b/docs/node-mixin/dashboards/node.libsonnet
@@ -264,7 +264,7 @@ local logPanel = grafana.logPanel;
         timezone='utc',
         refresh='30s',
         graphTooltip='shared_crosshair'
-      )      
+      )
       .addTemplate(
         {
           current: {
@@ -309,7 +309,7 @@ local logPanel = grafana.logPanel;
         template.new(
           'instance',
           '$datasource',
-          'label_values(node_exporter_build_info{%(nodeExporterSelector)s}, instance)',
+          'label_values(node_exporter_build_info{%(nodeExporterSelector)s}, instance)' % $._config,
           refresh='time',
         )
       )
@@ -360,5 +360,5 @@ local logPanel = grafana.logPanel;
         .addPanel(journalkernel)
         .addPanel(journalstdout)
       ),
-  },  
+  },
 }

--- a/docs/node-mixin/dashboards/node.libsonnet
+++ b/docs/node-mixin/dashboards/node.libsonnet
@@ -9,201 +9,290 @@ local gauge = promgrafonnet.gauge;
 local loki = grafana.loki;
 local logPanel = grafana.logPanel;
 
+local c = import '../config.libsonnet';
+
+local datasourceTemplate = {
+  current: {
+    text: 'Prometheus',
+    value: 'Prometheus',
+  },
+  hide: 0,
+  label: 'Data Source',
+  name: 'datasource',
+  options: [],
+  query: 'prometheus',
+  refresh: 1,
+  regex: '',
+  type: 'datasource',
+};
+
 {
-  grafanaDashboards+:: {
-    'nodes.json':
-      local idleCPU =
-        graphPanel.new(
-          'CPU Usage',
-          datasource='$datasource',
-          span=6,
-          format='percentunit',
-          max=1,
-          min=0,
-          stack=true,
+  _idleCPUPanel ::
+    graphPanel.new(
+      'CPU Usage',
+      datasource='$datasource',
+      span=6,
+      format='percentunit',
+      max=1,
+      min=0,
+      stack=true,
+    )
+    .addTarget(prometheus.target(
+      |||
+        (
+          (1 - sum without (mode) (rate(node_cpu_seconds_total{%(nodeExporterSelector)s, mode=~"idle|iowait|steal", instance="$instance"}[$__rate_interval])))
+        / ignoring(cpu) group_left
+          count without (cpu, mode) (node_cpu_seconds_total{%(nodeExporterSelector)s, mode="idle", instance="$instance"})
         )
-        .addTarget(prometheus.target(
-          |||
-            (
-              (1 - sum without (mode) (rate(node_cpu_seconds_total{%(nodeExporterSelector)s, mode=~"idle|iowait|steal", instance="$instance"}[$__rate_interval])))
-            / ignoring(cpu) group_left
-              count without (cpu, mode) (node_cpu_seconds_total{%(nodeExporterSelector)s, mode="idle", instance="$instance"})
-            )
-          ||| % $._config,
-          legendFormat='{{cpu}}',
-          intervalFactor=5,
-        ));
+      ||| % $._config,
+      legendFormat='{{cpu}}',
+      intervalFactor=5,
+    )),
 
-      local systemLoad =
-        graphPanel.new(
-          'Load Average',
-          datasource='$datasource',
-          span=6,
-          format='short',
-          min=0,
-          fill=0,
+  _systemLoadPanel ::
+    graphPanel.new(
+      'Load Average',
+      datasource='$datasource',
+      span=6,
+      format='short',
+      min=0,
+      fill=0,
+    )
+    .addTarget(prometheus.target('node_load1{%(nodeExporterSelector)s, instance="$instance"}' % $._config, legendFormat='1m load average'))
+    .addTarget(prometheus.target('node_load5{%(nodeExporterSelector)s, instance="$instance"}' % $._config, legendFormat='5m load average'))
+    .addTarget(prometheus.target('node_load15{%(nodeExporterSelector)s, instance="$instance"}' % $._config, legendFormat='15m load average'))
+    .addTarget(prometheus.target('count(node_cpu_seconds_total{%(nodeExporterSelector)s, instance="$instance", mode="idle"})' % $._config, legendFormat='logical cores')),
+
+  _memoryGraphPanel ::
+    graphPanel.new(
+      'Memory Usage',
+      datasource='$datasource',
+      span=9,
+      format='bytes',
+      stack=true,
+      min=0,
+    )
+    .addTarget(prometheus.target(
+      |||
+        (
+          node_memory_MemTotal_bytes{%(nodeExporterSelector)s, instance="$instance"}
+        -
+          node_memory_MemFree_bytes{%(nodeExporterSelector)s, instance="$instance"}
+        -
+          node_memory_Buffers_bytes{%(nodeExporterSelector)s, instance="$instance"}
+        -
+          node_memory_Cached_bytes{%(nodeExporterSelector)s, instance="$instance"}
         )
-        .addTarget(prometheus.target('node_load1{%(nodeExporterSelector)s, instance="$instance"}' % $._config, legendFormat='1m load average'))
-        .addTarget(prometheus.target('node_load5{%(nodeExporterSelector)s, instance="$instance"}' % $._config, legendFormat='5m load average'))
-        .addTarget(prometheus.target('node_load15{%(nodeExporterSelector)s, instance="$instance"}' % $._config, legendFormat='15m load average'))
-        .addTarget(prometheus.target('count(node_cpu_seconds_total{%(nodeExporterSelector)s, instance="$instance", mode="idle"})' % $._config, legendFormat='logical cores'));
+      ||| % $._config,
+      legendFormat='memory used'
+    ))
+    .addTarget(prometheus.target('node_memory_Buffers_bytes{%(nodeExporterSelector)s, instance="$instance"}' % $._config, legendFormat='memory buffers'))
+    .addTarget(prometheus.target('node_memory_Cached_bytes{%(nodeExporterSelector)s, instance="$instance"}' % $._config, legendFormat='memory cached'))
+    .addTarget(prometheus.target('node_memory_MemFree_bytes{%(nodeExporterSelector)s, instance="$instance"}' % $._config, legendFormat='memory free')),
 
-      local memoryGraph =
-        graphPanel.new(
-          'Memory Usage',
-          datasource='$datasource',
-          span=9,
-          format='bytes',
-          stack=true,
-          min=0,
-        )
-        .addTarget(prometheus.target(
-          |||
-            (
-              node_memory_MemTotal_bytes{%(nodeExporterSelector)s, instance="$instance"}
-            -
-              node_memory_MemFree_bytes{%(nodeExporterSelector)s, instance="$instance"}
-            -
-              node_memory_Buffers_bytes{%(nodeExporterSelector)s, instance="$instance"}
-            -
-              node_memory_Cached_bytes{%(nodeExporterSelector)s, instance="$instance"}
-            )
-          ||| % $._config,
-          legendFormat='memory used'
-        ))
-        .addTarget(prometheus.target('node_memory_Buffers_bytes{%(nodeExporterSelector)s, instance="$instance"}' % $._config, legendFormat='memory buffers'))
-        .addTarget(prometheus.target('node_memory_Cached_bytes{%(nodeExporterSelector)s, instance="$instance"}' % $._config, legendFormat='memory cached'))
-        .addTarget(prometheus.target('node_memory_MemFree_bytes{%(nodeExporterSelector)s, instance="$instance"}' % $._config, legendFormat='memory free'));
+  // TODO: It would be nicer to have a gauge that gets a 0-1 range and displays it as a percentage 0%-100%.
+  // This needs to be added upstream in the promgrafonnet library and then changed here.
+  // NOTE: avg() is used to circumvent a label change caused by a node_exporter rollout.
+  _memoryGaugePanel :: gauge.new(
+    'Memory Usage',
+    |||
+      100 -
+      (
+        avg(node_memory_MemAvailable_bytes{%(nodeExporterSelector)s, instance="$instance"})
+      /
+        avg(node_memory_MemTotal_bytes{%(nodeExporterSelector)s, instance="$instance"})
+      * 100
+      )
+    ||| % $._config,
+  ).withLowerBeingBetter(),
 
-      // TODO: It would be nicer to have a gauge that gets a 0-1 range and displays it as a percentage 0%-100%.
-      // This needs to be added upstream in the promgrafonnet library and then changed here.
-      // NOTE: avg() is used to circumvent a label change caused by a node_exporter rollout.
-      local memoryGauge = gauge.new(
-        'Memory Usage',
-        |||
-          100 -
-          (
-            avg(node_memory_MemAvailable_bytes{%(nodeExporterSelector)s, instance="$instance"})
-          /
-            avg(node_memory_MemTotal_bytes{%(nodeExporterSelector)s, instance="$instance"})
-          * 100
-          )
-        ||| % $._config,
-      ).withLowerBeingBetter();
-
-      local diskIO =
-        graphPanel.new(
-          'Disk I/O',
-          datasource='$datasource',
-          span=6,
-          min=0,
-          fill=0,
-        )
-        // TODO: Does it make sense to have those three in the same panel?
-        .addTarget(prometheus.target(
-          'rate(node_disk_read_bytes_total{%(nodeExporterSelector)s, instance="$instance", %(diskDeviceSelector)s}[$__rate_interval])' % $._config,
-          legendFormat='{{device}} read',
-        ))
-        .addTarget(prometheus.target(
-          'rate(node_disk_written_bytes_total{%(nodeExporterSelector)s, instance="$instance", %(diskDeviceSelector)s}[$__rate_interval])' % $._config,
-          legendFormat='{{device}} written',
-        ))
-        .addTarget(prometheus.target(
-          'rate(node_disk_io_time_seconds_total{%(nodeExporterSelector)s, instance="$instance", %(diskDeviceSelector)s}[$__rate_interval])' % $._config,
-          legendFormat='{{device}} io time',
-        )) +
+  _diskIOPanel ::
+    graphPanel.new(
+      'Disk I/O',
+      datasource='$datasource',
+      span=6,
+      min=0,
+      fill=0,
+    )
+    // TODO: Does it make sense to have those three in the same panel?
+    .addTarget(prometheus.target(
+      'rate(node_disk_read_bytes_total{%(nodeExporterSelector)s, instance="$instance", %(diskDeviceSelector)s}[$__rate_interval])' % $._config,
+      legendFormat='{{device}} read',
+    ))
+    .addTarget(prometheus.target(
+      'rate(node_disk_written_bytes_total{%(nodeExporterSelector)s, instance="$instance", %(diskDeviceSelector)s}[$__rate_interval])' % $._config,
+      legendFormat='{{device}} written',
+    ))
+    .addTarget(prometheus.target(
+      'rate(node_disk_io_time_seconds_total{%(nodeExporterSelector)s, instance="$instance", %(diskDeviceSelector)s}[$__rate_interval])' % $._config,
+      legendFormat='{{device}} io time',
+    )) +
+    {
+      seriesOverrides: [
         {
-          seriesOverrides: [
-            {
-              alias: '/ read| written/',
-              yaxis: 1,
-            },
-            {
-              alias: '/ io time/',
-              yaxis: 2,
-            },
-          ],
-          yaxes: [
-            self.yaxe(format='bytes'),
-            self.yaxe(format='s'),
-          ],
-        };
+          alias: '/ read| written/',
+          yaxis: 1,
+        },
+        {
+          alias: '/ io time/',
+          yaxis: 2,
+        },
+      ],
+      yaxes: [
+        self.yaxe(format='bytes'),
+        self.yaxe(format='s'),
+      ],
+    },
 
       // TODO: Somehow partition this by device while excluding read-only devices.
-      local diskSpaceUsage =
-        graphPanel.new(
-          'Disk Space Usage',
-          datasource='$datasource',
-          span=6,
-          format='bytes',
-          min=0,
-          fill=1,
-          stack=true,
+  _diskSpaceUsagePanel ::
+    graphPanel.new(
+      'Disk Space Usage',
+      datasource='$datasource',
+      span=6,
+      format='bytes',
+      min=0,
+      fill=1,
+      stack=true,
+    )
+    .addTarget(prometheus.target(
+      |||
+        sum(
+          max by (device) (
+            node_filesystem_size_bytes{%(nodeExporterSelector)s, instance="$instance", %(fsSelector)s}
+          -
+            node_filesystem_avail_bytes{%(nodeExporterSelector)s, instance="$instance", %(fsSelector)s}
+          )
         )
-        .addTarget(prometheus.target(
-          |||
-            sum(
-              max by (device) (
-                node_filesystem_size_bytes{%(nodeExporterSelector)s, instance="$instance", %(fsSelector)s}
-              -
-                node_filesystem_avail_bytes{%(nodeExporterSelector)s, instance="$instance", %(fsSelector)s}
-              )
-            )
-          ||| % $._config,
-          legendFormat='used',
-        ))
-        .addTarget(prometheus.target(
-          |||
-            sum(
-              max by (device) (
-                node_filesystem_avail_bytes{%(nodeExporterSelector)s, instance="$instance", %(fsSelector)s}
-              )
-            )
-          ||| % $._config,
-          legendFormat='available',
-        )) +
+      ||| % $._config,
+      legendFormat='used',
+    ))
+    .addTarget(prometheus.target(
+      |||
+        sum(
+          max by (device) (
+            node_filesystem_avail_bytes{%(nodeExporterSelector)s, instance="$instance", %(fsSelector)s}
+          )
+        )
+      ||| % $._config,
+      legendFormat='available',
+    )) +
+    {
+      seriesOverrides: [
         {
-          seriesOverrides: [
-            {
-              alias: 'used',
-              color: '#E0B400',
-            },
-            {
-              alias: 'available',
-              color: '#73BF69',
-            },
-          ],
+          alias: 'used',
+          color: '#E0B400',
+        },
+        {
+          alias: 'available',
+          color: '#73BF69',
+        },
+      ],
+    },
+
+  _networkReceivedPanel ::
+    graphPanel.new(
+      'Network Received',
+      datasource='$datasource',
+      span=6,
+      format='bytes',
+      min=0,
+      fill=0,
+    )
+    .addTarget(prometheus.target(
+      'rate(node_network_receive_bytes_total{%(nodeExporterSelector)s, instance="$instance", device!="lo"}[$__rate_interval])' % $._config,
+      legendFormat='{{device}}',
+    )),
+
+  _networkTransmittedPanel ::
+    graphPanel.new(
+      'Network Transmitted',
+      datasource='$datasource',
+      span=6,
+      format='bytes',
+      min=0,
+      fill=0,
+    )
+    .addTarget(prometheus.target(
+      'rate(node_network_transmit_bytes_total{%(nodeExporterSelector)s, instance="$instance", device!="lo"}[$__rate_interval])' % $._config,
+      legendFormat='{{device}}',
+    )),
+
+  _cpuRow ::
+    row.new('CPU')
+    .addPanel($._idleCPUPanel)
+    .addPanel($._systemLoadPanel),
+
+  _memoryRow ::
+    row.new('Memory')
+    .addPanel($._memoryGraphPanel)
+    .addPanel($._memoryGaugePanel),
+
+  _diskRow ::
+    row.new('Disk')
+    .addPanel($._diskIOPanel)
+    .addPanel($._diskSpaceUsagePanel),
+
+  _networkRow ::
+    row.new('Network')
+    .addPanel($._networkReceivedPanel)
+    .addPanel($._networkTransmittedPanel),
+
+  _instanceTemplate:: template.new(
+    'instance',
+    '$datasource',
+    'label_values(node_exporter_build_info{%(nodeExporterSelector)s}, instance)' % $._config,
+    refresh='time',
+  ),
+
+  _NodeDashboard:: dashboard.new(
+    '%sNodes' % $._config.dashboardNamePrefix,
+    time_from='now-1h',
+    tags=($._config.dashboardTags),
+    timezone='utc',
+    refresh='30s',
+    graphTooltip='shared_crosshair'
+  ),
+   
+  grafanaDashboards+:: 
+    if !$._config.enableLokiLogs then {
+      'nodes.json':
+        $._NodeDashboard
+        .addTemplate(datasourceTemplate)
+        .addTemplate($._instanceTemplate)
+        .addRow($._cpuRow)
+        .addRow($._memoryRow)
+        .addRow($._diskRow)
+        .addRow($._networkRow), 
+    }
+    else {
+      'nodes.json':
+
+        local lokiDatasourceTemplate = {
+          current: 
+          {
+            text: 'Loki',
+            value: 'Loki',
+          },          
+          label: 'Loki Data Source',
+          name: 'logs_datasource',
+          options: [],
+          query: 'loki',
+          hide: if $._config.enableLokiLogs then '' else '2',
+          refresh: 1,
+          regex: '',
+          type: 'datasource',         
         };
 
-      local networkReceived =
-        graphPanel.new(
-          'Network Received',
-          datasource='$datasource',
-          span=6,
-          format='bytes',
-          min=0,
-          fill=0,
-        )
-        .addTarget(prometheus.target(
-          'rate(node_network_receive_bytes_total{%(nodeExporterSelector)s, instance="$instance", device!="lo"}[$__rate_interval])' % $._config,
-          legendFormat='{{device}}',
-        ));
+        local jobTemplate = template.new(
+          'job',
+          '$datasource',
+          'label_values(node_exporter_build_info, job)',
+          hide= if $._config.enableLokiLogs then '' else '2',
+          refresh='time',          
+        );
 
-      local networkTransmitted =
-        graphPanel.new(
-          'Network Transmitted',
-          datasource='$datasource',
-          span=6,
-          format='bytes',
-          min=0,
-          fill=0,
-        )
-        .addTarget(prometheus.target(
-          'rate(node_network_transmit_bytes_total{%(nodeExporterSelector)s, instance="$instance", device!="lo"}[$__rate_interval])' % $._config,
-          legendFormat='{{device}}',
-        ));
-
-      local syslog = 
+        local syslog = 
         logPanel.new(
           'syslog Errors',
           datasource='$logs_datasource',
@@ -212,153 +301,77 @@ local logPanel = grafana.logPanel;
           loki.target('{filename=~"/var/log/syslog*|/var/log/messages*", %(nodeExporterSelector)s, instance=~"$instance"} |~".+(?i)error(?-i).+"' % $._config)
         );
 
-      local authlog = 
-        logPanel.new(
-          'authlog',
-          datasource='$logs_datasource',
-        )
-        .addTarget(
-          loki.target('{filename=~"/var/log/auth.log|/var/log/secure", %(nodeExporterSelector)s, instance=~"$instance"}' % $._config)
-        );
+        local authlog = 
+          logPanel.new(
+            'authlog',
+            datasource='$logs_datasource',
+          )
+          .addTarget(
+            loki.target('{filename=~"/var/log/auth.log|/var/log/secure", %(nodeExporterSelector)s, instance=~"$instance"}' % $._config)
+          );
 
-      local kernellog = 
-        logPanel.new(
-          'Kernel logs',
-          datasource='$logs_datasource',
-        )
-        .addTarget(
-          loki.target('{filename=~"/var/log/kern.log*", %(nodeExporterSelector)s, instance=~"$instance"}' % $._config)
-        );
-        
-      local journalsyslog = 
-        logPanel.new(
-          'Journal syslogs',
-          datasource='$logs_datasource',
-        )
-        .addTarget(
-          loki.target('{transport="syslog", %(nodeExporterSelector)s, instance=~"$instance"}' % $._config)
-        );
-        
-      local journalkernel = 
-        logPanel.new(
-          'Journal Kernel logs',
-          datasource='$logs_datasource',
-        )
-        .addTarget(
-          loki.target('{transport="kernel", %(nodeExporterSelector)s, instance=~"$instance"}' % $._config)
-        );
-        
-      local journalstdout = 
-        logPanel.new(
-          'Journal stdout Errors',
-          datasource='$logs_datasource',
-        )
-        .addTarget(
-          loki.target('{transport="stdout", %(nodeExporterSelector)s, instance=~"$instance", unit=~"$unit"} |~".+(?i)error(?-i).+"' % $._config)
-        );
-        
-      dashboard.new(
-        '%sNodes' % $._config.dashboardNamePrefix,
-        time_from='now-1h',
-        tags=($._config.dashboardTags),
-        timezone='utc',
-        refresh='30s',
-        graphTooltip='shared_crosshair'
-      )
-      .addTemplate(
-        {
-          current: {
-            text: 'Prometheus',
-            value: 'Prometheus',
-          },
-          hide: 0,
-          label: 'Data Source',
-          name: 'datasource',
-          options: [],
-          query: 'prometheus',
-          refresh: 1,
-          regex: '',
-          type: 'datasource',
-        },
-      )
-      .addTemplate(
-        {
-          current: {
-            text: 'Loki',
-            value: 'Loki',
-          },
-          hide: 0,
-          label: 'Loki Data Source',
-          name: 'logs_datasource',
-          options: [],
-          query: 'loki',
-          refresh: 1,
-          regex: '',
-          type: 'datasource',
-        },
-      )
-      .addTemplate(
-        template.new(
-          'job',
-          '$datasource',
-          'label_values(node_exporter_build_info, job)',
-          refresh='time',
-        )
-      )
-      .addTemplate(
-        template.new(
-          'instance',
-          '$datasource',
-          'label_values(node_exporter_build_info{%(nodeExporterSelector)s}, instance)' % $._config,
-          refresh='time',
-        )
-      )
-      .addTemplate(
-        template.new(
-          'unit',
-          '$logs_datasource',
-          'label_values(unit)',
-          refresh='time',
-          includeAll=true,
-          multi=true,
-          allValues='.+',
-        )
-      )
-      .addRow(
-        row.new()
-        .addPanel(idleCPU)
-        .addPanel(systemLoad)
-      )
-      .addRow(
-        row.new()
-        .addPanel(memoryGraph)
-        .addPanel(memoryGauge)
-      )
-      .addRow(
-        row.new()
-        .addPanel(diskIO)
-        .addPanel(diskSpaceUsage)
-      )
-      .addRow(
-        row.new()
-        .addPanel(networkReceived)
-        .addPanel(networkTransmitted)
-      )
-      .addRow(
-        row.new(
-          'Direct Log Scrapes'
-        )
-        .addPanel(syslog)
-        .addPanel(authlog)
-        .addPanel(kernellog)
-      )
-      .addRow(
-        row.new(
-          'Journal Log Scrapes'
-        )
-        .addPanel(journalsyslog)
-        .addPanel(journalkernel)
-        .addPanel(journalstdout)
-      ),
-  },
+        local kernellog = 
+          logPanel.new(
+            'Kernel logs',
+            datasource='$logs_datasource',
+          )
+          .addTarget(
+            loki.target('{filename=~"/var/log/kern.log*", %(nodeExporterSelector)s, instance=~"$instance"}' % $._config)
+          );
+          
+        local journalsyslog = 
+          logPanel.new(
+            'Journal syslogs',
+            datasource='$logs_datasource',
+          )
+          .addTarget(
+            loki.target('{transport="syslog", %(nodeExporterSelector)s, instance=~"$instance"}' % $._config)
+          );
+          
+        local journalkernel = 
+          logPanel.new(
+            'Journal Kernel logs',
+            datasource='$logs_datasource',
+          )
+          .addTarget(
+            loki.target('{transport="kernel", %(nodeExporterSelector)s, instance=~"$instance"}' % $._config)
+          );
+          
+        local journalstdout = 
+          logPanel.new(
+            'Journal stdout Errors',
+            datasource='$logs_datasource',
+          )
+          .addTarget(
+            loki.target('{transport="stdout", %(nodeExporterSelector)s, instance=~"$instance", unit=~"$unit"} |~".+(?i)error(?-i).+"' % $._config)
+          );
+
+        local lokiDirectLogRow = 
+          row.new(
+            'Loki Direct Log Scrapes'
+          )
+          .addPanel(syslog)
+          .addPanel(authlog)
+          .addPanel(kernellog);
+
+        local lokiJournalLogRow = 
+          row.new(
+            'Loki Journal Log Scrapes'
+          )
+          .addPanel(journalsyslog)
+          .addPanel(journalkernel)
+          .addPanel(journalstdout);
+
+        $._NodeDashboard
+        .addTemplate(datasourceTemplate)
+        .addTemplate(lokiDatasourceTemplate)
+        .addTemplate(jobTemplate)      
+        .addTemplate($._instanceTemplate)
+        .addRow($._cpuRow)
+        .addRow($._memoryRow)
+        .addRow($._diskRow)
+        .addRow($._networkRow)
+        .addRow(lokiDirectLogRow)
+        .addRow(lokiJournalLogRow),             
+    }, 
 }

--- a/docs/node-mixin/dashboards/use.libsonnet
+++ b/docs/node-mixin/dashboards/use.libsonnet
@@ -143,7 +143,7 @@ local diskSpaceUtilisation =
     sort=1
   ),
 
-  __node_rsrc_use_dashboard:: 
+  __node_rsrc_use_dashboard::
       dashboard.new(
         '%sUSE Method / Node' % $._config.dashboardNamePrefix,
         time_from='now-1h',
@@ -209,7 +209,7 @@ local diskSpaceUtilisation =
       ),
 
   grafanaDashboards+::
-      if !$._config.enableLokiLogs then {        
+      if !$._config.enableLokiLogs then {
         'node-rsrc-use.json':
           $.__node_rsrc_use_dashboard,
       }
@@ -277,7 +277,7 @@ local diskSpaceUtilisation =
             .addTarget(
               loki.target('{filename=~"/var/log/kern.log*", %(nodeExporterSelector)s, instance=~"$instance", %(clusterLabel)s="$cluster"}}' % $._config)
             );
-            
+
           local journalsyslog = 
             logPanel.new(
               'Journal syslogs',
@@ -286,7 +286,7 @@ local diskSpaceUtilisation =
             .addTarget(
               loki.target('{transport="syslog", %(nodeExporterSelector)s, instance=~"$instance", %(clusterLabel)s="$cluster"}}' % $._config)
             );
-            
+
           local journalkernel = 
             logPanel.new(
               'Journal Kernel logs',
@@ -295,7 +295,7 @@ local diskSpaceUtilisation =
             .addTarget(
               loki.target('{transport="kernel", %(nodeExporterSelector)s, instance=~"$instance", %(clusterLabel)s="$cluster"}}' % $._config)
             );
-            
+
           local journalstdout = 
             logPanel.new(
               'Journal stdout Errors',
@@ -305,7 +305,7 @@ local diskSpaceUtilisation =
               loki.target('{transport="stdout", %(nodeExporterSelector)s, instance=~"$instance", %(clusterLabel)s="$cluster"}, unit=~"$unit"} |~".+(?i)error(?-i).+"' % $._config)
             );
 
-          local lokiDirectLogRow = 
+          local lokiDirectLogRow =
             row.new(
               'Loki Direct Log Scrapes'
             )

--- a/docs/node-mixin/dashboards/use.libsonnet
+++ b/docs/node-mixin/dashboards/use.libsonnet
@@ -4,6 +4,8 @@ local row = grafana.row;
 local prometheus = grafana.prometheus;
 local template = grafana.template;
 local graphPanel = grafana.graphPanel;
+local loki = grafana.loki;
+local logPanel = grafana.logPanel;
 
 local c = import '../config.libsonnet';
 
@@ -14,7 +16,7 @@ local datasourceTemplate = {
   },
   hide: 0,
   label: 'Data Source',
-  name: 'datasource',
+  name: 'prometheus_datasource',
   options: [],
   query: 'prometheus',
   refresh: 1,
@@ -25,7 +27,7 @@ local datasourceTemplate = {
 local CPUUtilisation =
   graphPanel.new(
     'CPU Utilisation',
-    datasource='$datasource',
+    datasource='$prometheus_datasource',
     span=6,
     format='percentunit',
     stack=true,
@@ -38,7 +40,7 @@ local CPUSaturation =
   // average relates to the "CPU saturation" in the title.
   graphPanel.new(
     'CPU Saturation (Load1 per CPU)',
-    datasource='$datasource',
+    datasource='$prometheus_datasource',
     span=6,
     format='percentunit',
     stack=true,
@@ -49,7 +51,7 @@ local CPUSaturation =
 local memoryUtilisation =
   graphPanel.new(
     'Memory Utilisation',
-    datasource='$datasource',
+    datasource='$prometheus_datasource',
     span=6,
     format='percentunit',
     stack=true,
@@ -60,7 +62,7 @@ local memoryUtilisation =
 local memorySaturation =
   graphPanel.new(
     'Memory Saturation (Major Page Faults)',
-    datasource='$datasource',
+    datasource='$prometheus_datasource',
     span=6,
     format='rds',
     stack=true,
@@ -71,7 +73,7 @@ local memorySaturation =
 local networkUtilisation =
   graphPanel.new(
     'Network Utilisation (Bytes Receive/Transmit)',
-    datasource='$datasource',
+    datasource='$prometheus_datasource',
     span=6,
     format='Bps',
     stack=true,
@@ -85,7 +87,7 @@ local networkUtilisation =
 local networkSaturation =
   graphPanel.new(
     'Network Saturation (Drops Receive/Transmit)',
-    datasource='$datasource',
+    datasource='$prometheus_datasource',
     span=6,
     format='Bps',
     stack=true,
@@ -99,7 +101,7 @@ local networkSaturation =
 local diskIOUtilisation =
   graphPanel.new(
     'Disk IO Utilisation',
-    datasource='$datasource',
+    datasource='$prometheus_datasource',
     span=6,
     format='percentunit',
     stack=true,
@@ -110,7 +112,7 @@ local diskIOUtilisation =
 local diskIOSaturation =
   graphPanel.new(
     'Disk IO Saturation',
-    datasource='$datasource',
+    datasource='$prometheus_datasource',
     span=6,
     format='percentunit',
     stack=true,
@@ -121,7 +123,7 @@ local diskIOSaturation =
 local diskSpaceUtilisation =
   graphPanel.new(
     'Disk Space Utilisation',
-    datasource='$datasource',
+    datasource='$prometheus_datasource',
     span=12,
     format='percentunit',
     stack=true,
@@ -132,335 +134,459 @@ local diskSpaceUtilisation =
 {
   _clusterTemplate:: template.new(
     name='cluster',
-    datasource='$datasource',
+    datasource='$prometheus_datasource',
     query='label_values(node_time_seconds, %s)' % $._config.clusterLabel,
     current='',
-    hide=if $._config.showMultiCluster then '' else '2',
+    hide=if $._config.showMultiCluster then 0 else 2,
     refresh=2,
     includeAll=false,
     sort=1
   ),
 
-  grafanaDashboards+:: {
-                         'node-rsrc-use.json':
+  __node_rsrc_use_dashboard:: 
+      dashboard.new(
+        '%sUSE Method / Node' % $._config.dashboardNamePrefix,
+        time_from='now-1h',
+        tags=($._config.dashboardTags),
+        timezone='utc',
+        refresh='30s',
+        graphTooltip='shared_crosshair'
+      )
+      .addTemplate(datasourceTemplate)
+      .addTemplate($._clusterTemplate)
+      .addTemplate(
+        template.new(
+          'instance',
+          '$prometheus_datasource',
+          'label_values(node_exporter_build_info{%(nodeExporterSelector)s, %(clusterLabel)s="$cluster"}, instance)' % $._config,
+          refresh='time',
+          sort=1
+        )
+      )
+      .addRow(
+        row.new('CPU')
+        .addPanel(CPUUtilisation.addTarget(prometheus.target('instance:node_cpu_utilisation:rate%(rateInterval)s{%(nodeExporterSelector)s, instance="$instance", %(clusterLabel)s="$cluster"} != 0' % $._config, legendFormat='Utilisation')))
+        .addPanel(CPUSaturation.addTarget(prometheus.target('instance:node_load1_per_cpu:ratio{%(nodeExporterSelector)s, instance="$instance", %(clusterLabel)s="$cluster"} != 0' % $._config, legendFormat='Saturation')))
+      )
+      .addRow(
+        row.new('Memory')
+        .addPanel(memoryUtilisation.addTarget(prometheus.target('instance:node_memory_utilisation:ratio{%(nodeExporterSelector)s, instance="$instance", %(clusterLabel)s="$cluster"} != 0' % $._config, legendFormat='Utilisation')))
+        .addPanel(memorySaturation.addTarget(prometheus.target('instance:node_vmstat_pgmajfault:rate%(rateInterval)s{%(nodeExporterSelector)s, instance="$instance", %(clusterLabel)s="$cluster"} != 0' % $._config, legendFormat='Major page Faults')))
+      )
+      .addRow(
+        row.new('Network')
+        .addPanel(
+          networkUtilisation
+          .addTarget(prometheus.target('instance:node_network_receive_bytes_excluding_lo:rate%(rateInterval)s{%(nodeExporterSelector)s, instance="$instance", %(clusterLabel)s="$cluster"} != 0' % $._config, legendFormat='Receive'))
+          .addTarget(prometheus.target('instance:node_network_transmit_bytes_excluding_lo:rate%(rateInterval)s{%(nodeExporterSelector)s, instance="$instance", %(clusterLabel)s="$cluster"} != 0' % $._config, legendFormat='Transmit'))
+        )
+        .addPanel(
+          networkSaturation
+          .addTarget(prometheus.target('instance:node_network_receive_drop_excluding_lo:rate%(rateInterval)s{%(nodeExporterSelector)s, instance="$instance", %(clusterLabel)s="$cluster"} != 0' % $._config, legendFormat='Receive'))
+          .addTarget(prometheus.target('instance:node_network_transmit_drop_excluding_lo:rate%(rateInterval)s{%(nodeExporterSelector)s, instance="$instance", %(clusterLabel)s="$cluster"} != 0' % $._config, legendFormat='Transmit'))
+        )
+      )
+      .addRow(
+        row.new('Disk IO')
+        .addPanel(diskIOUtilisation.addTarget(prometheus.target('instance_device:node_disk_io_time_seconds:rate%(rateInterval)s{%(nodeExporterSelector)s, instance="$instance", %(clusterLabel)s="$cluster"} != 0' % $._config, legendFormat='{{device}}')))
+        .addPanel(diskIOSaturation.addTarget(prometheus.target('instance_device:node_disk_io_time_weighted_seconds:rate%(rateInterval)s{%(nodeExporterSelector)s, instance="$instance", %(clusterLabel)s="$cluster"} != 0' % $._config, legendFormat='{{device}}')))
+      )
+      .addRow(
+        row.new('Disk Space')
+        .addPanel(
+          diskSpaceUtilisation.addTarget(prometheus.target(
+            |||
+              sort_desc(1 -
+                (
+                max without (mountpoint, fstype) (node_filesystem_avail_bytes{%(nodeExporterSelector)s, fstype!="", instance="$instance", %(clusterLabel)s="$cluster"})
+                /
+                max without (mountpoint, fstype) (node_filesystem_size_bytes{%(nodeExporterSelector)s, fstype!="", instance="$instance", %(clusterLabel)s="$cluster"})
+                ) != 0
+              )
+            ||| % $._config, legendFormat='{{device}}'
+          ))
+        )
+      ),
 
-                           dashboard.new(
-                             '%sUSE Method / Node' % $._config.dashboardNamePrefix,
-                             time_from='now-1h',
-                             tags=($._config.dashboardTags),
-                             timezone='utc',
-                             refresh='30s',
-                             graphTooltip='shared_crosshair'
-                           )
-                           .addTemplate(datasourceTemplate)
-                           .addTemplate($._clusterTemplate)
-                           .addTemplate(
-                             template.new(
-                               'instance',
-                               '$datasource',
-                               'label_values(node_exporter_build_info{%(nodeExporterSelector)s, %(clusterLabel)s="$cluster"}, instance)' % $._config,
-                               refresh='time',
-                               sort=1
-                             )
-                           )
-                           .addRow(
-                             row.new('CPU')
-                             .addPanel(CPUUtilisation.addTarget(prometheus.target('instance:node_cpu_utilisation:rate%(rateInterval)s{%(nodeExporterSelector)s, instance="$instance", %(clusterLabel)s="$cluster"} != 0' % $._config, legendFormat='Utilisation')))
-                             .addPanel(CPUSaturation.addTarget(prometheus.target('instance:node_load1_per_cpu:ratio{%(nodeExporterSelector)s, instance="$instance", %(clusterLabel)s="$cluster"} != 0' % $._config, legendFormat='Saturation')))
-                           )
-                           .addRow(
-                             row.new('Memory')
-                             .addPanel(memoryUtilisation.addTarget(prometheus.target('instance:node_memory_utilisation:ratio{%(nodeExporterSelector)s, instance="$instance", %(clusterLabel)s="$cluster"} != 0' % $._config, legendFormat='Utilisation')))
-                             .addPanel(memorySaturation.addTarget(prometheus.target('instance:node_vmstat_pgmajfault:rate%(rateInterval)s{%(nodeExporterSelector)s, instance="$instance", %(clusterLabel)s="$cluster"} != 0' % $._config, legendFormat='Major page Faults')))
-                           )
-                           .addRow(
-                             row.new('Network')
-                             .addPanel(
-                               networkUtilisation
-                               .addTarget(prometheus.target('instance:node_network_receive_bytes_excluding_lo:rate%(rateInterval)s{%(nodeExporterSelector)s, instance="$instance", %(clusterLabel)s="$cluster"} != 0' % $._config, legendFormat='Receive'))
-                               .addTarget(prometheus.target('instance:node_network_transmit_bytes_excluding_lo:rate%(rateInterval)s{%(nodeExporterSelector)s, instance="$instance", %(clusterLabel)s="$cluster"} != 0' % $._config, legendFormat='Transmit'))
-                             )
-                             .addPanel(
-                               networkSaturation
-                               .addTarget(prometheus.target('instance:node_network_receive_drop_excluding_lo:rate%(rateInterval)s{%(nodeExporterSelector)s, instance="$instance", %(clusterLabel)s="$cluster"} != 0' % $._config, legendFormat='Receive'))
-                               .addTarget(prometheus.target('instance:node_network_transmit_drop_excluding_lo:rate%(rateInterval)s{%(nodeExporterSelector)s, instance="$instance", %(clusterLabel)s="$cluster"} != 0' % $._config, legendFormat='Transmit'))
-                             )
-                           )
-                           .addRow(
-                             row.new('Disk IO')
-                             .addPanel(diskIOUtilisation.addTarget(prometheus.target('instance_device:node_disk_io_time_seconds:rate%(rateInterval)s{%(nodeExporterSelector)s, instance="$instance", %(clusterLabel)s="$cluster"} != 0' % $._config, legendFormat='{{device}}')))
-                             .addPanel(diskIOSaturation.addTarget(prometheus.target('instance_device:node_disk_io_time_weighted_seconds:rate%(rateInterval)s{%(nodeExporterSelector)s, instance="$instance", %(clusterLabel)s="$cluster"} != 0' % $._config, legendFormat='{{device}}')))
-                           )
-                           .addRow(
-                             row.new('Disk Space')
-                             .addPanel(
-                               diskSpaceUtilisation.addTarget(prometheus.target(
-                                 |||
-                                   sort_desc(1 -
-                                     (
-                                      max without (mountpoint, fstype) (node_filesystem_avail_bytes{%(nodeExporterSelector)s, fstype!="", instance="$instance", %(clusterLabel)s="$cluster"})
-                                      /
-                                      max without (mountpoint, fstype) (node_filesystem_size_bytes{%(nodeExporterSelector)s, fstype!="", instance="$instance", %(clusterLabel)s="$cluster"})
-                                     ) != 0
-                                   )
-                                 ||| % $._config, legendFormat='{{device}}'
-                               ))
-                             )
-                           ),
+  grafanaDashboards+::
+      if !$._config.enableLokiLogs then {        
+        'node-rsrc-use.json':
+          $.__node_rsrc_use_dashboard,
+      }
+      else {
+        'node-rsrc-use.json':
+          local lokiDatasourceTemplate = {
+            current: 
+            {
+              text: 'Loki',
+              value: 'Loki',
+            },                    
+            name: 'loki_datasource',
+            label: 'Loki Data Source',
+            options: [],
+            query: 'loki',
+            hide: 0,
+            refresh: 1,
+            regex: '',
+            type: 'datasource',         
+          };
 
-                         'node-cluster-rsrc-use.json':
-                           dashboard.new(
-                             '%sUSE Method / Cluster' % $._config.dashboardNamePrefix,
-                             time_from='now-1h',
-                             tags=($._config.dashboardTags),
-                             timezone='utc',
-                             refresh='30s',
-                             graphTooltip='shared_crosshair'
-                           )
-                           .addTemplate(datasourceTemplate)
-                           .addTemplate($._clusterTemplate)
-                           .addRow(
-                             row.new('CPU')
-                             .addPanel(
-                               CPUUtilisation
-                               .addTarget(prometheus.target(
-                                 |||
-                                   ((
-                                     instance:node_cpu_utilisation:rate%(rateInterval)s{%(nodeExporterSelector)s, %(clusterLabel)s="$cluster"}
-                                     *
-                                     instance:node_num_cpu:sum{%(nodeExporterSelector)s, %(clusterLabel)s="$cluster"}
-                                   ) != 0 )
-                                   / scalar(sum(instance:node_num_cpu:sum{%(nodeExporterSelector)s, %(clusterLabel)s="$cluster"}))
-                                 ||| % $._config, legendFormat='{{ instance }}'
-                               ))
-                             )
-                             .addPanel(
-                               CPUSaturation
-                               .addTarget(prometheus.target(
-                                 |||
-                                   (
-                                     instance:node_load1_per_cpu:ratio{%(nodeExporterSelector)s, %(clusterLabel)s="$cluster"}
-                                     / scalar(count(instance:node_load1_per_cpu:ratio{%(nodeExporterSelector)s, %(clusterLabel)s="$cluster"}))
-                                   )  != 0
-                                 ||| % $._config, legendFormat='{{instance}}'
-                               ))
-                             )
-                           )
-                           .addRow(
-                             row.new('Memory')
-                             .addPanel(
-                               memoryUtilisation
-                               .addTarget(prometheus.target(
-                                 |||
-                                   (
-                                     instance:node_memory_utilisation:ratio{%(nodeExporterSelector)s, %(clusterLabel)s="$cluster"}
-                                     / scalar(count(instance:node_memory_utilisation:ratio{%(nodeExporterSelector)s, %(clusterLabel)s="$cluster"}))
-                                   ) != 0
-                                 ||| % $._config, legendFormat='{{instance}}',
-                               ))
-                             )
-                             .addPanel(memorySaturation.addTarget(prometheus.target('instance:node_vmstat_pgmajfault:rate%(rateInterval)s{%(nodeExporterSelector)s, %(clusterLabel)s="$cluster"}' % $._config, legendFormat='{{instance}}')))
-                           )
-                           .addRow(
-                             row.new('Network')
-                             .addPanel(
-                               networkUtilisation
-                               .addTarget(prometheus.target('instance:node_network_receive_bytes_excluding_lo:rate%(rateInterval)s{%(nodeExporterSelector)s, %(clusterLabel)s="$cluster"} != 0' % $._config, legendFormat='{{instance}} Receive'))
-                               .addTarget(prometheus.target('instance:node_network_transmit_bytes_excluding_lo:rate%(rateInterval)s{%(nodeExporterSelector)s, %(clusterLabel)s="$cluster"} != 0' % $._config, legendFormat='{{instance}} Transmit'))
-                             )
-                             .addPanel(
-                               networkSaturation
-                               .addTarget(prometheus.target('instance:node_network_receive_drop_excluding_lo:rate%(rateInterval)s{%(nodeExporterSelector)s, %(clusterLabel)s="$cluster"} != 0' % $._config, legendFormat='{{instance}} Receive'))
-                               .addTarget(prometheus.target('instance:node_network_transmit_drop_excluding_lo:rate%(rateInterval)s{%(nodeExporterSelector)s, %(clusterLabel)s="$cluster"} != 0' % $._config, legendFormat='{{instance}} Transmit'))
-                             )
-                           )
-                           .addRow(
-                             row.new('Disk IO')
-                             .addPanel(
-                               diskIOUtilisation
-                               .addTarget(prometheus.target(
-                                 |||
-                                   (
-                                     instance_device:node_disk_io_time_seconds:rate%(rateInterval)s{%(nodeExporterSelector)s, %(clusterLabel)s="$cluster"}
-                                     / scalar(count(instance_device:node_disk_io_time_seconds:rate%(rateInterval)s{%(nodeExporterSelector)s, %(clusterLabel)s="$cluster"}))
-                                   ) != 0
-                                 ||| % $._config, legendFormat='{{instance}} {{device}}'
-                               ))
-                             )
-                             .addPanel(
-                               diskIOSaturation
-                               .addTarget(prometheus.target(
-                                 |||
-                                   (
-                                     instance_device:node_disk_io_time_weighted_seconds:rate%(rateInterval)s{%(nodeExporterSelector)s, %(clusterLabel)s="$cluster"}
-                                     / scalar(count(instance_device:node_disk_io_time_weighted_seconds:rate%(rateInterval)s{%(nodeExporterSelector)s, %(clusterLabel)s="$cluster"}))
-                                   ) != 0
-                                 ||| % $._config, legendFormat='{{instance}} {{device}}'
-                               ))
-                             )
-                           )
-                           .addRow(
-                             row.new('Disk Space')
-                             .addPanel(
-                               diskSpaceUtilisation
-                               .addTarget(prometheus.target(
-                                 |||
-                                   sum without (device) (
-                                     max without (fstype, mountpoint) ((
-                                       node_filesystem_size_bytes{%(nodeExporterSelector)s, %(fsSelector)s, %(clusterLabel)s="$cluster"}
-                                       -
-                                       node_filesystem_avail_bytes{%(nodeExporterSelector)s, %(fsSelector)s, %(clusterLabel)s="$cluster"}
-                                     ) != 0)
-                                   )
-                                   / scalar(sum(max without (fstype, mountpoint) (node_filesystem_size_bytes{%(nodeExporterSelector)s, %(fsSelector)s, %(clusterLabel)s="$cluster"})))
-                                 ||| % $._config, legendFormat='{{instance}}'
-                               ))
-                             )
-                           ),
-                       } +
-                       if $._config.showMultiCluster then {
-                         'node-multicluster-rsrc-use.json':
-                           dashboard.new(
-                             '%sUSE Method / Multi-cluster' % $._config.dashboardNamePrefix,
-                             time_from='now-1h',
-                             tags=($._config.dashboardTags),
-                             timezone='utc',
-                             refresh='30s',
-                             graphTooltip='shared_crosshair'
-                           )
-                           .addTemplate(datasourceTemplate)
-                           .addRow(
-                             row.new('CPU')
-                             .addPanel(
-                               CPUUtilisation
-                               .addTarget(prometheus.target(
-                                 |||
-                                   sum(
-                                     ((
-                                       instance:node_cpu_utilisation:rate%(rateInterval)s{%(nodeExporterSelector)s}
-                                       *
-                                       instance:node_num_cpu:sum{%(nodeExporterSelector)s}
-                                     ) != 0)
-                                     / scalar(sum(instance:node_num_cpu:sum{%(nodeExporterSelector)s}))
-                                   ) by (%(clusterLabel)s)
-                                 ||| % $._config, legendFormat='{{%(clusterLabel)s}}' % $._config
-                               ))
-                             )
-                             .addPanel(
-                               CPUSaturation
-                               .addTarget(prometheus.target(
-                                 |||
-                                   sum((
-                                     instance:node_load1_per_cpu:ratio{%(nodeExporterSelector)s}
-                                     / scalar(count(instance:node_load1_per_cpu:ratio{%(nodeExporterSelector)s}))
-                                   ) != 0) by (%(clusterLabel)s)
-                                 ||| % $._config, legendFormat='{{%(clusterLabel)s}}' % $._config
-                               ))
-                             )
-                           )
-                           .addRow(
-                             row.new('Memory')
-                             .addPanel(
-                               memoryUtilisation
-                               .addTarget(prometheus.target(
-                                 |||
-                                   sum((
-                                       instance:node_memory_utilisation:ratio{%(nodeExporterSelector)s}
-                                       / scalar(count(instance:node_memory_utilisation:ratio{%(nodeExporterSelector)s}))
-                                   ) != 0) by (%(clusterLabel)s)
-                                 ||| % $._config, legendFormat='{{%(clusterLabel)s}}' % $._config
-                               ))
-                             )
-                             .addPanel(
-                               memorySaturation
-                               .addTarget(prometheus.target(
-                                 |||
-                                   sum((
-                                       instance:node_vmstat_pgmajfault:rate%(rateInterval)s{%(nodeExporterSelector)s}
-                                   ) != 0) by (%(clusterLabel)s)
-                                 ||| % $._config, legendFormat='{{%(clusterLabel)s}}' % $._config
-                               ))
-                             )
-                           )
-                           .addRow(
-                             row.new('Network')
-                             .addPanel(
-                               networkUtilisation
-                               .addTarget(prometheus.target(
-                                 |||
-                                   sum((
-                                       instance:node_network_receive_bytes_excluding_lo:rate%(rateInterval)s{%(nodeExporterSelector)s}
-                                   ) != 0) by (%(clusterLabel)s)
-                                 ||| % $._config, legendFormat='{{%(clusterLabel)s}} Receive' % $._config
-                               ))
-                               .addTarget(prometheus.target(
-                                 |||
-                                   sum((
-                                       instance:node_network_transmit_bytes_excluding_lo:rate%(rateInterval)s{%(nodeExporterSelector)s}
-                                   ) != 0) by (%(clusterLabel)s)
-                                 ||| % $._config, legendFormat='{{%(clusterLabel)s}} Transmit' % $._config
-                               ))
-                             )
-                             .addPanel(
-                               networkSaturation
-                               .addTarget(prometheus.target(
-                                 |||
-                                   sum((
-                                       instance:node_network_receive_drop_excluding_lo:rate%(rateInterval)s{%(nodeExporterSelector)s}
-                                   ) != 0) by (%(clusterLabel)s)
-                                 ||| % $._config, legendFormat='{{%(clusterLabel)s}} Receive' % $._config
-                               ))
-                               .addTarget(prometheus.target(
-                                 |||
-                                   sum((
-                                       instance:node_network_transmit_drop_excluding_lo:rate%(rateInterval)s{%(nodeExporterSelector)s}
-                                   ) != 0) by (%(clusterLabel)s)
-                                 ||| % $._config, legendFormat='{{%(clusterLabel)s}} Transmit' % $._config
-                               ))
-                             )
-                           )
-                           .addRow(
-                             row.new('Disk IO')
-                             .addPanel(
-                               diskIOUtilisation
-                               .addTarget(prometheus.target(
-                                 |||
-                                   sum((
-                                       instance_device:node_disk_io_time_seconds:rate%(rateInterval)s{%(nodeExporterSelector)s}
-                                       / scalar(count(instance_device:node_disk_io_time_seconds:rate%(rateInterval)s{%(nodeExporterSelector)s}))
-                                   ) != 0) by (%(clusterLabel)s, device)
-                                 ||| % $._config, legendFormat='{{%(clusterLabel)s}} {{device}}' % $._config
-                               ))
-                             )
-                             .addPanel(
-                               diskIOSaturation
-                               .addTarget(prometheus.target(
-                                 |||
-                                   sum((
-                                     instance_device:node_disk_io_time_weighted_seconds:rate%(rateInterval)s{%(nodeExporterSelector)s}
-                                     / scalar(count(instance_device:node_disk_io_time_weighted_seconds:rate%(rateInterval)s{%(nodeExporterSelector)s}))
-                                   ) != 0) by (%(clusterLabel)s, device)
-                                 ||| % $._config, legendFormat='{{%(clusterLabel)s}} {{device}}' % $._config
-                               ))
-                             )
-                           )
-                           .addRow(
-                             row.new('Disk Space')
-                             .addPanel(
-                               diskSpaceUtilisation
-                               .addTarget(prometheus.target(
-                                 |||
-                                   sum (
-                                     sum without (device) (
-                                       max without (fstype, mountpoint, instance, pod) ((
-                                         node_filesystem_size_bytes{%(nodeExporterSelector)s, %(fsSelector)s} - node_filesystem_avail_bytes{%(nodeExporterSelector)s, %(fsSelector)s}
-                                       ) != 0)
-                                     )
-                                     / scalar(sum(max without (fstype, mountpoint) (node_filesystem_size_bytes{%(nodeExporterSelector)s, %(fsSelector)s})))
-                                   ) by (%(clusterLabel)s)
-                                 ||| % $._config, legendFormat='{{%(clusterLabel)s}}' % $._config
-                               ))
-                             )
-                           ),
-                       } else {},
+          local jobTemplate = template.new(
+            'job',
+            '$prometheus_datasource',
+            'label_values(node_exporter_build_info, job)',
+            hide= 0,
+            label='Job',
+            refresh='time',          
+          );
+
+          local unitTemplate = template.new(
+            'unit',
+            '$loki_datasource',
+            'label_values(unit)',
+            label= 'Systemd Unit',
+            refresh='time',
+            includeAll=true,
+            multi=true,
+            allValues='.+',
+          );
+
+          local syslog = 
+          logPanel.new(
+            'syslog Errors',
+            datasource='$loki_datasource',
+          )
+          .addTarget(
+            loki.target('{filename=~"/var/log/syslog*|/var/log/messages*", %(nodeExporterSelector)s, instance=~"$instance", %(clusterLabel)s="$cluster"}} |~".+(?i)error(?-i).+"' % $._config)
+          );
+
+          local authlog = 
+            logPanel.new(
+              'authlog',
+              datasource='$loki_datasource',
+            )
+            .addTarget(
+              loki.target('{filename=~"/var/log/auth.log|/var/log/secure", %(nodeExporterSelector)s, instance=~"$instance", %(clusterLabel)s="$cluster"}}' % $._config)
+            );
+
+          local kernellog = 
+            logPanel.new(
+              'Kernel logs',
+              datasource='$loki_datasource',
+            )
+            .addTarget(
+              loki.target('{filename=~"/var/log/kern.log*", %(nodeExporterSelector)s, instance=~"$instance", %(clusterLabel)s="$cluster"}}' % $._config)
+            );
+            
+          local journalsyslog = 
+            logPanel.new(
+              'Journal syslogs',
+              datasource='$loki_datasource',
+            )
+            .addTarget(
+              loki.target('{transport="syslog", %(nodeExporterSelector)s, instance=~"$instance", %(clusterLabel)s="$cluster"}}' % $._config)
+            );
+            
+          local journalkernel = 
+            logPanel.new(
+              'Journal Kernel logs',
+              datasource='$loki_datasource',
+            )
+            .addTarget(
+              loki.target('{transport="kernel", %(nodeExporterSelector)s, instance=~"$instance", %(clusterLabel)s="$cluster"}}' % $._config)
+            );
+            
+          local journalstdout = 
+            logPanel.new(
+              'Journal stdout Errors',
+              datasource='$loki_datasource',
+            )
+            .addTarget(
+              loki.target('{transport="stdout", %(nodeExporterSelector)s, instance=~"$instance", %(clusterLabel)s="$cluster"}, unit=~"$unit"} |~".+(?i)error(?-i).+"' % $._config)
+            );
+
+          local lokiDirectLogRow = 
+            row.new(
+              'Loki Direct Log Scrapes'
+            )
+            .addPanel(syslog)
+            .addPanel(authlog)
+            .addPanel(kernellog);
+
+          local lokiJournalLogRow = 
+            row.new(
+              'Loki Journal Log Scrapes'
+            )
+            .addPanel(journalsyslog)
+            .addPanel(journalkernel)
+            .addPanel(journalstdout);
+
+          $.__node_rsrc_use_dashboard
+          .addTemplate(lokiDatasourceTemplate)
+          .addTemplate(jobTemplate)      
+          .addTemplate($._instanceTemplate)
+          .addTemplate(unitTemplate)
+          .addRow($._cpuRow)
+          .addRow($._memoryRow)
+          .addRow($._diskRow)
+          .addRow($._networkRow)
+          .addRow(lokiDirectLogRow)
+          .addRow(lokiJournalLogRow)       
+      } +
+
+      if $._config.showMultiCluster then {
+      'node-multicluster-rsrc-use.json':
+        dashboard.new(
+          '%sUSE Method / Multi-cluster' % $._config.dashboardNamePrefix,
+          time_from='now-1h',
+          tags=($._config.dashboardTags),
+          timezone='utc',
+          refresh='30s',
+          graphTooltip='shared_crosshair'
+        )
+        .addTemplate(datasourceTemplate)
+        .addRow(
+          row.new('CPU')
+          .addPanel(
+            CPUUtilisation
+            .addTarget(prometheus.target(
+              |||
+                sum(
+                  ((
+                    instance:node_cpu_utilisation:rate%(rateInterval)s{%(nodeExporterSelector)s}
+                    *
+                    instance:node_num_cpu:sum{%(nodeExporterSelector)s}
+                  ) != 0)
+                  / scalar(sum(instance:node_num_cpu:sum{%(nodeExporterSelector)s}))
+                ) by (%(clusterLabel)s)
+              ||| % $._config, legendFormat='{{%(clusterLabel)s}}' % $._config
+            ))
+          )
+          .addPanel(
+            CPUSaturation
+            .addTarget(prometheus.target(
+              |||
+                sum((
+                  instance:node_load1_per_cpu:ratio{%(nodeExporterSelector)s}
+                  / scalar(count(instance:node_load1_per_cpu:ratio{%(nodeExporterSelector)s}))
+                ) != 0) by (%(clusterLabel)s)
+              ||| % $._config, legendFormat='{{%(clusterLabel)s}}' % $._config
+            ))
+          )
+        )
+        .addRow(
+          row.new('Memory')
+          .addPanel(
+            memoryUtilisation
+            .addTarget(prometheus.target(
+              |||
+                sum((
+                    instance:node_memory_utilisation:ratio{%(nodeExporterSelector)s}
+                    / scalar(count(instance:node_memory_utilisation:ratio{%(nodeExporterSelector)s}))
+                ) != 0) by (%(clusterLabel)s)
+              ||| % $._config, legendFormat='{{%(clusterLabel)s}}' % $._config
+            ))
+          )
+          .addPanel(
+            memorySaturation
+            .addTarget(prometheus.target(
+              |||
+                sum((
+                    instance:node_vmstat_pgmajfault:rate%(rateInterval)s{%(nodeExporterSelector)s}
+                ) != 0) by (%(clusterLabel)s)
+              ||| % $._config, legendFormat='{{%(clusterLabel)s}}' % $._config
+            ))
+          )
+        )
+        .addRow(
+          row.new('Network')
+          .addPanel(
+            networkUtilisation
+            .addTarget(prometheus.target(
+              |||
+                sum((
+                    instance:node_network_receive_bytes_excluding_lo:rate%(rateInterval)s{%(nodeExporterSelector)s}
+                ) != 0) by (%(clusterLabel)s)
+              ||| % $._config, legendFormat='{{%(clusterLabel)s}} Receive' % $._config
+            ))
+            .addTarget(prometheus.target(
+              |||
+                sum((
+                    instance:node_network_transmit_bytes_excluding_lo:rate%(rateInterval)s{%(nodeExporterSelector)s}
+                ) != 0) by (%(clusterLabel)s)
+              ||| % $._config, legendFormat='{{%(clusterLabel)s}} Transmit' % $._config
+            ))
+          )
+          .addPanel(
+            networkSaturation
+            .addTarget(prometheus.target(
+              |||
+                sum((
+                    instance:node_network_receive_drop_excluding_lo:rate%(rateInterval)s{%(nodeExporterSelector)s}
+                ) != 0) by (%(clusterLabel)s)
+              ||| % $._config, legendFormat='{{%(clusterLabel)s}} Receive' % $._config
+            ))
+            .addTarget(prometheus.target(
+              |||
+                sum((
+                    instance:node_network_transmit_drop_excluding_lo:rate%(rateInterval)s{%(nodeExporterSelector)s}
+                ) != 0) by (%(clusterLabel)s)
+              ||| % $._config, legendFormat='{{%(clusterLabel)s}} Transmit' % $._config
+            ))
+          )
+        )
+        .addRow(
+          row.new('Disk IO')
+          .addPanel(
+            diskIOUtilisation
+            .addTarget(prometheus.target(
+              |||
+                sum((
+                    instance_device:node_disk_io_time_seconds:rate%(rateInterval)s{%(nodeExporterSelector)s}
+                    / scalar(count(instance_device:node_disk_io_time_seconds:rate%(rateInterval)s{%(nodeExporterSelector)s}))
+                ) != 0) by (%(clusterLabel)s, device)
+              ||| % $._config, legendFormat='{{%(clusterLabel)s}} {{device}}' % $._config
+            ))
+          )
+          .addPanel(
+            diskIOSaturation
+            .addTarget(prometheus.target(
+              |||
+                sum((
+                  instance_device:node_disk_io_time_weighted_seconds:rate%(rateInterval)s{%(nodeExporterSelector)s}
+                  / scalar(count(instance_device:node_disk_io_time_weighted_seconds:rate%(rateInterval)s{%(nodeExporterSelector)s}))
+                ) != 0) by (%(clusterLabel)s, device)
+              ||| % $._config, legendFormat='{{%(clusterLabel)s}} {{device}}' % $._config
+            ))
+          )
+        )
+        .addRow(
+          row.new('Disk Space')
+          .addPanel(
+            diskSpaceUtilisation
+            .addTarget(prometheus.target(
+              |||
+                sum (
+                  sum without (device) (
+                    max without (fstype, mountpoint, instance, pod) ((
+                      node_filesystem_size_bytes{%(nodeExporterSelector)s, %(fsSelector)s} - node_filesystem_avail_bytes{%(nodeExporterSelector)s, %(fsSelector)s}
+                    ) != 0)
+                  )
+                  / scalar(sum(max without (fstype, mountpoint) (node_filesystem_size_bytes{%(nodeExporterSelector)s, %(fsSelector)s})))
+                ) by (%(clusterLabel)s)
+              ||| % $._config, legendFormat='{{%(clusterLabel)s}}' % $._config
+            ))
+          )
+        ),
+    } else {},
+
+    'node-cluster-rsrc-use.json':
+      dashboard.new(
+        '%sUSE Method / Cluster' % $._config.dashboardNamePrefix,
+        time_from='now-1h',
+        tags=($._config.dashboardTags),
+        timezone='utc',
+        refresh='30s',
+        graphTooltip='shared_crosshair'
+      )
+      .addTemplate(datasourceTemplate)
+      .addTemplate($._clusterTemplate)
+      .addRow(
+        row.new('CPU')
+        .addPanel(
+          CPUUtilisation
+          .addTarget(prometheus.target(
+            |||
+              ((
+                instance:node_cpu_utilisation:rate%(rateInterval)s{%(nodeExporterSelector)s, %(clusterLabel)s="$cluster"}
+                *
+                instance:node_num_cpu:sum{%(nodeExporterSelector)s, %(clusterLabel)s="$cluster"}
+              ) != 0 )
+              / scalar(sum(instance:node_num_cpu:sum{%(nodeExporterSelector)s, %(clusterLabel)s="$cluster"}))
+            ||| % $._config, legendFormat='{{ instance }}'
+          ))
+        )
+        .addPanel(
+          CPUSaturation
+          .addTarget(prometheus.target(
+            |||
+              (
+                instance:node_load1_per_cpu:ratio{%(nodeExporterSelector)s, %(clusterLabel)s="$cluster"}
+                / scalar(count(instance:node_load1_per_cpu:ratio{%(nodeExporterSelector)s, %(clusterLabel)s="$cluster"}))
+              )  != 0
+            ||| % $._config, legendFormat='{{instance}}'
+          ))
+        )
+      )
+      .addRow(
+        row.new('Memory')
+        .addPanel(
+          memoryUtilisation
+          .addTarget(prometheus.target(
+            |||
+              (
+                instance:node_memory_utilisation:ratio{%(nodeExporterSelector)s, %(clusterLabel)s="$cluster"}
+                / scalar(count(instance:node_memory_utilisation:ratio{%(nodeExporterSelector)s, %(clusterLabel)s="$cluster"}))
+              ) != 0
+            ||| % $._config, legendFormat='{{instance}}',
+          ))
+        )
+        .addPanel(memorySaturation.addTarget(prometheus.target('instance:node_vmstat_pgmajfault:rate%(rateInterval)s{%(nodeExporterSelector)s, %(clusterLabel)s="$cluster"}' % $._config, legendFormat='{{instance}}')))
+      )
+      .addRow(
+        row.new('Network')
+        .addPanel(
+          networkUtilisation
+          .addTarget(prometheus.target('instance:node_network_receive_bytes_excluding_lo:rate%(rateInterval)s{%(nodeExporterSelector)s, %(clusterLabel)s="$cluster"} != 0' % $._config, legendFormat='{{instance}} Receive'))
+          .addTarget(prometheus.target('instance:node_network_transmit_bytes_excluding_lo:rate%(rateInterval)s{%(nodeExporterSelector)s, %(clusterLabel)s="$cluster"} != 0' % $._config, legendFormat='{{instance}} Transmit'))
+        )
+        .addPanel(
+          networkSaturation
+          .addTarget(prometheus.target('instance:node_network_receive_drop_excluding_lo:rate%(rateInterval)s{%(nodeExporterSelector)s, %(clusterLabel)s="$cluster"} != 0' % $._config, legendFormat='{{instance}} Receive'))
+          .addTarget(prometheus.target('instance:node_network_transmit_drop_excluding_lo:rate%(rateInterval)s{%(nodeExporterSelector)s, %(clusterLabel)s="$cluster"} != 0' % $._config, legendFormat='{{instance}} Transmit'))
+        )
+      )
+      .addRow(
+        row.new('Disk IO')
+        .addPanel(
+          diskIOUtilisation
+          .addTarget(prometheus.target(
+            |||
+              (
+                instance_device:node_disk_io_time_seconds:rate%(rateInterval)s{%(nodeExporterSelector)s, %(clusterLabel)s="$cluster"}
+                / scalar(count(instance_device:node_disk_io_time_seconds:rate%(rateInterval)s{%(nodeExporterSelector)s, %(clusterLabel)s="$cluster"}))
+              ) != 0
+            ||| % $._config, legendFormat='{{instance}} {{device}}'
+          ))
+        )
+        .addPanel(
+          diskIOSaturation
+          .addTarget(prometheus.target(
+            |||
+              (
+                instance_device:node_disk_io_time_weighted_seconds:rate%(rateInterval)s{%(nodeExporterSelector)s, %(clusterLabel)s="$cluster"}
+                / scalar(count(instance_device:node_disk_io_time_weighted_seconds:rate%(rateInterval)s{%(nodeExporterSelector)s, %(clusterLabel)s="$cluster"}))
+              ) != 0
+            ||| % $._config, legendFormat='{{instance}} {{device}}'
+          ))
+        )
+      )
+      .addRow(
+        row.new('Disk Space')
+        .addPanel(
+          diskSpaceUtilisation
+          .addTarget(prometheus.target(
+            |||
+              sum without (device) (
+                max without (fstype, mountpoint) ((
+                  node_filesystem_size_bytes{%(nodeExporterSelector)s, %(fsSelector)s, %(clusterLabel)s="$cluster"}
+                  -
+                  node_filesystem_avail_bytes{%(nodeExporterSelector)s, %(fsSelector)s, %(clusterLabel)s="$cluster"}
+                ) != 0)
+              )
+              / scalar(sum(max without (fstype, mountpoint) (node_filesystem_size_bytes{%(nodeExporterSelector)s, %(fsSelector)s, %(clusterLabel)s="$cluster"})))
+            ||| % $._config, legendFormat='{{instance}}'
+          ))
+        )
+      ),
 }

--- a/docs/node-mixin/jsonnetfile.json
+++ b/docs/node-mixin/jsonnetfile.json
@@ -13,8 +13,8 @@
     {
       "source": {
         "git": {
-          "remote": "https://github.com/grafana/jsonnet-libs.git",
-          "subdir": "grafana-builder"
+          "remote": "https://github.com/grafana/grafonnet-lib.git",
+          "subdir": "grafonnet-7.0"
         }
       },
       "version": "master"
@@ -22,12 +22,12 @@
     {
       "source": {
         "git": {
-          "remote": "https://github.com/kubernetes-monitoring/kubernetes-mixin.git",
-          "subdir": "lib/promgrafonnet"
+          "remote": "https://github.com/grafana/jsonnet-libs.git",
+          "subdir": ""
         }
       },
       "version": "master"
     }
   ],
-  "legacyImports": false
+  "legacyImports": true
 }


### PR DESCRIPTION
This PR adds 6 panels for logs using Loki datasource. I am taking two different log sources here:

1. 3 panels (syslog errors, kernel logs and auth log) being targeted to logs scraped directly from the log files, using promtail.
2. 3 other panels (syslog, kernel, stdout) being targeted to logs scraped from journal. 

I decided to add those 2 sources for some reasons:

Journal gives us many labels out-of-the-box, including an unit label for stdout which categorizes the log producer systemd application, giving the user the possibility to navigate logs from a specific application. It is not every application that uses systemd, though. That`s why the first group of panels includes one targeted at syslog errors, which should be useful if this applications is writing to stdout, directing it to syslog by default.

I am also replicating the kernel logs, in case the user don`t want to give the Grafana Agent access permissions directly to the file.

The auth information is very important and I could not find a way to get it from journal, so it is going to be exclusive for direct scraping, as long as me or someone finds out a way to do it.

Right now I am only changing the Node dahsboard, as soon as those changes are approved I will also include it into the USE Method dashboard.

I also inluded a job template variable, so that if there are many job templates the user can select which one he wants.

Here are some screenshots:

![image](https://user-images.githubusercontent.com/9431850/154546323-b6b50ca8-372c-4bfd-b276-bfc63c53897f.png)
![image](https://user-images.githubusercontent.com/9431850/154546400-94ca858d-1ad0-4b9f-b57e-97dd9c9f0fe7.png)

