### PR TITLE
Logs update

### DIFF
--- a/docs/node-mixin/config.libsonnet
+++ b/docs/node-mixin/config.libsonnet
@@ -60,6 +60,7 @@
     dashboardNamePrefix: 'Node Exporter / ',
     dashboardTags: ['node-exporter-mixin'],
 
-    enableLokiLogs: false,
+    // Set to true to add log panels to dashboards
+    enableLokiLogs: true,
   },
 }

--- a/docs/node-mixin/config.libsonnet
+++ b/docs/node-mixin/config.libsonnet
@@ -61,6 +61,6 @@
     dashboardTags: ['node-exporter-mixin'],
 
     // Set to true to add log panels to dashboards
-    enableLokiLogs: true,
+    enableLokiLogs: false,
   },
 }

--- a/docs/node-mixin/dashboards/node.libsonnet
+++ b/docs/node-mixin/dashboards/node.libsonnet
@@ -272,10 +272,8 @@ local gaugePanel = grafana70.panel.gauge;
       local l = lokiMixin.new('%(nodeExporterSelector)s, instance="$instance"' % $._config),
       'nodes.json':
         NodeDashboard
-        .addTemplate(l.lokiDatasourceTemplate)
-        .addTemplate(l.unitTemplate)
-        .addRow(l.lokiDirectLogRow)
-        .addRow(l.lokiJournalLogRow),
+        .addTemplates(l.templates)
+        .addRows(l.rows),
     }
     else {
       'nodes.json':

--- a/docs/node-mixin/dashboards/use.libsonnet
+++ b/docs/node-mixin/dashboards/use.libsonnet
@@ -7,8 +7,6 @@ local graphPanel = grafana.graphPanel;
 local loki = grafana.loki;
 local logPanel = grafana.logPanel;
 
-local c = import '../config.libsonnet';
-
 local datasourceTemplate = {
   current: {
     text: 'default',

--- a/docs/node-mixin/dashboards/use.libsonnet
+++ b/docs/node-mixin/dashboards/use.libsonnet
@@ -317,12 +317,7 @@ local diskSpaceUtilisation =
 
           $._node_rsrc_use_dashboard
           .addTemplate(lokiDatasourceTemplate)
-          .addTemplate($._instanceTemplate)
           .addTemplate(unitTemplate)
-          .addRow($._cpuRow)
-          .addRow($._memoryRow)
-          .addRow($._diskRow)
-          .addRow($._networkRow)
           .addRow(lokiDirectLogRow)
           .addRow(lokiJournalLogRow),
       } +

--- a/docs/node-mixin/lib/lokimixin/loki-mixin.libsonnet
+++ b/docs/node-mixin/lib/lokimixin/loki-mixin.libsonnet
@@ -1,0 +1,120 @@
+local grafana = import 'github.com/grafana/grafonnet-lib/grafonnet/grafana.libsonnet';
+local row = grafana.row;
+local template = grafana.template;
+local logPanel = grafana.logPanel;
+local loki = grafana.loki;
+
+{
+  new(dashboardSelector=null):: {
+    lokiDatasourceTemplate:: {
+      current:
+        {
+          text: 'Loki',
+          value: 'Loki',
+        },
+      name: 'loki_datasource',
+      label: 'Loki Data Source',
+      options: [],
+      query: 'loki',
+      hide: 0,
+      refresh: 1,
+      regex: '',
+      type: 'datasource',
+    },
+
+    unitTemplate:: template.new(
+      'unit',
+      '$loki_datasource',
+      'label_values(unit)',
+      label='Systemd Unit',
+      refresh='time',
+      includeAll=true,
+      multi=true,
+      allValues='.+',
+    ),
+
+    syslog::
+      logPanel.new(
+        'syslog Errors',
+        datasource='$loki_datasource',
+      )
+      .addTarget(
+        loki.target('{filename=~"/var/log/syslog*|/var/log/messages*", %s} |~".+(?i)error(?-i).+"' % dashboardSelector)
+      ),
+
+    authlog::
+      logPanel.new(
+        'authlog',
+        datasource='$loki_datasource',
+      )
+      .addTarget(
+        loki.target('{filename=~"/var/log/auth.log|/var/log/secure", %s}' % dashboardSelector)
+      ),
+
+    kernellog::
+      logPanel.new(
+        'Kernel logs',
+        datasource='$loki_datasource',
+      )
+      .addTarget(
+        loki.target('{filename=~"/var/log/kern.log*", %s}' % dashboardSelector)
+      ),
+
+    journalsyslog::
+      logPanel.new(
+        'Journal syslogs',
+        datasource='$loki_datasource',
+      )
+      .addTarget(
+        loki.target('{transport="syslog", %s}' % dashboardSelector)
+      ),
+
+    journalkernel::
+      logPanel.new(
+        'Journal Kernel logs',
+        datasource='$loki_datasource',
+      )
+      .addTarget(
+        loki.target('{transport="kernel", %s}' % dashboardSelector)
+      ),
+
+    journalstdout::
+      logPanel.new(
+        'Journal stdout Errors',
+        datasource='$loki_datasource',
+      )
+      .addTarget(
+        loki.target('{transport="stdout", %s, unit=~"$unit"} |~".+(?i)error(?-i).+"' % dashboardSelector)
+      ),
+
+    lokiDirectLogRow::
+      row.new(
+        'Loki Direct Log Scrapes'
+      )
+      .addPanel(self.syslog)
+      .addPanel(self.authlog)
+      .addPanel(self.kernellog),
+
+    lokiJournalLogRow::
+      row.new(
+        'Loki Journal Log Scrapes'
+      )
+      .addPanel(self.journalsyslog)
+      .addPanel(self.journalkernel)
+      .addPanel(self.journalstdout),
+
+    rows::
+      [
+        self.lokiDirectLogRow,
+        self.lokiJournalLogRow,
+      ],
+
+    templates::
+      [
+        self.lokiDatasourceTemplate,
+        self.unitTemplate,
+      ],
+
+  },
+
+}


### PR DESCRIPTION
- Merged two logs rows into one:
> This commit combines view of logs from Journald and file scraping inside the single row.
Since most of the modern systems use systemd, we can suggest that users should prefer journald configuration for promtail ( since it has more labels out of the box, due to its binary format) and use file scraping only if the system doesn’t support journald.
Here is the preview of combined logs row. It searches for logs from both sources though, so dashboard would fall back to showing logs for hosts where journald  is not available.   
- Moved loki related panels/templates into lib file
- Removed node dashboard' rows from 'USE' dashboard
![image](https://user-images.githubusercontent.com/14870891/163570338-9f108079-2938-48fa-b6ed-656e4ec176f8.png)
