### PR TITLE
Mixtool and dashboard-linter tweaks.

### DIFF
--- a/docs/node-mixin/.lint
+++ b/docs/node-mixin/.lint
@@ -1,0 +1,56 @@
+---
+exclusions:
+  template-datasource-rule:
+    reason: using the not yet implemented new convention for dashboards with Loki and Prometheus datasources.
+  panel-datasource-rule:
+    reason: using the not yet implemented new convention for dashboards with Loki and Prometheus datasources.
+  target-job-rule:
+    reason: Job is hardcoded by the mixin.
+    entries:
+    - dashboard: Node Exporter / USE Method / Node
+    - dashboard: Node Exporter / Nodes
+    - dashboard: Node Exporter / MacOS
+    - dashboard: Node Exporter / USE Method / Multi-cluster
+    - dashboard: Node Exporter / USE Method / Cluster
+  template-job-rule:
+    reason: Job is hardcoded by the mixin.
+    entries:
+    - dashboard: Node Exporter / USE Method / Node
+    - dashboard: Node Exporter / Nodes
+    - dashboard: Node Exporter / MacOS
+    - dashboard: Node Exporter / USE Method / Multi-cluster
+    - dashboard: Node Exporter / USE Method / Cluster
+  target-instance-rule:
+    entries:
+    - dashboard: Node Exporter / USE Method / Multi-cluster
+      reason: Instances are aggregated for all clusters
+    - dashboard: Node Exporter / USE Method / Cluster
+      reason: Instances are aggregated for the whole cluster
+    - dashboard: Node Exporter / USE Method / Node
+      reason: Dashboard only allows selecting a single instance at a time.
+    - dashboard: Node Exporter / Nodes
+      reason: Dashboard only allows selecting a single instance at a time.
+    - dashboard: Node Exporter / MacOS
+      reason: Dashboard only allows selecting a single instance at a time.
+  template-instance-rule:
+    entries:
+    - dashboard: Node Exporter / USE Method / Multi-cluster
+      reason: Instances are aggregated for all clusters
+    - dashboard: Node Exporter / USE Method / Cluster
+      reason: Instances are aggregated for the whole cluster
+    - dashboard: Node Exporter / Nodes
+      reason: Dashboard only allows selecting a single instance at a time.
+    - dashboard: Node Exporter / MacOS
+      reason: Ignoring mislabeling of instance template
+    - dashboard: Node Exporter / USE Method / Node
+      reason: Ignoring mislabeling of instance template
+  panel-units-rule:
+    entries:
+    - dashboard: Node Exporter / Nodes
+      reason: Units are indeed set for all but load average (which doesn't have a reasonable unit), but in the yaxis "format" property rather than in field config. The dashboard linter needs to be patched accordingly.
+    - dashboard: Node Exporter / MacOS
+      reason: Units are indeed set for all but load average (which doesn't have a reasonable unit), but in the yaxis "format" property rather than in field config. The dashboard linter needs to be patched accordingly.
+    - dashboard: Node Exporter / USE Method / Cluster
+      reason: Units are indeed set, but in the yaxis "format" property rather than in field config. The dashboard linter needs to be patched accordingly.
+    - dashboard: Node Exporter / USE Method / Node
+      reason: Units are indeed set, but in the yaxis "format" property rather than in field config. The dashboard linter needs to be patched accordingly.

--- a/docs/node-mixin/alerts/alerts.libsonnet
+++ b/docs/node-mixin/alerts/alerts.libsonnet
@@ -204,7 +204,7 @@
             ||| % $._config,
             annotations: {
               summary: 'Node Exporter text file collector failed to scrape.',
-              description: 'Node Exporter text file collector failed to scrape.',
+              description: 'Node Exporter text file collector on {{ $labels.instance }} failed to scrape.',
             },
             labels: {
               severity: 'warning',
@@ -260,7 +260,7 @@
               severity: 'critical',
             },
             annotations: {
-              summary: 'RAID Array is degraded',
+              summary: 'RAID Array is degraded.',
               description: "RAID array '{{ $labels.device }}' on {{ $labels.instance }} is in degraded state due to one or more disks failures. Number of spare drives is insufficient to fix issue automatically.",
             },
           },
@@ -273,7 +273,7 @@
               severity: 'warning',
             },
             annotations: {
-              summary: 'Failed device in RAID array',
+              summary: 'Failed device in RAID array.',
               description: "At least one device in RAID array on {{ $labels.instance }} failed. Array '{{ $labels.device }}' needs attention and possibly a disk swap.",
             },
           },

--- a/docs/node-mixin/dashboards.jsonnet
+++ b/docs/node-mixin/dashboards.jsonnet
@@ -1,6 +1,6 @@
 local dashboards = (import 'mixin.libsonnet').grafanaDashboards;
 
 {
-  [name]: dashboards[name]
+  [name]: dashboards[name] + { uid: std.md5(name) },
   for name in std.objectFields(dashboards)
 }

--- a/docs/node-mixin/dashboards/dashboards.libsonnet
+++ b/docs/node-mixin/dashboards/dashboards.libsonnet
@@ -1,2 +1,3 @@
 (import 'node.libsonnet') +
-(import 'use.libsonnet')
+(import 'use.libsonnet') +
+(import 'defaults.libsonnet')

--- a/docs/node-mixin/dashboards/defaults.libsonnet
+++ b/docs/node-mixin/dashboards/defaults.libsonnet
@@ -1,0 +1,8 @@
+{
+  local grafanaDashboards = super.grafanaDashboards,
+  grafanaDashboards::
+    {
+      [fname]: grafanaDashboards[fname] { uid: std.md5(fname) }
+      for fname in std.objectFields(grafanaDashboards)
+    },
+}

--- a/docs/node-mixin/dashboards/use.libsonnet
+++ b/docs/node-mixin/dashboards/use.libsonnet
@@ -25,6 +25,7 @@ local datasourceTemplate = {
 local CPUUtilisation =
   graphPanel.new(
     'CPU Utilisation',
+    description='Total CPU utilisation percent.',
     datasource='$datasource',
     span=6,
     format='percentunit',
@@ -38,6 +39,7 @@ local CPUSaturation =
   // average relates to the "CPU saturation" in the title.
   graphPanel.new(
     'CPU Saturation (Load1 per CPU)',
+    description='System load average over the last minute. A measurement of how many processes are waiting for CPU cycles. The maximum number is the number of CPU cores for the node.',
     datasource='$datasource',
     span=6,
     format='percentunit',
@@ -49,6 +51,7 @@ local CPUSaturation =
 local memoryUtilisation =
   graphPanel.new(
     'Memory Utilisation',
+    description='Total memory utilisation in bytes.',
     datasource='$datasource',
     span=6,
     format='percentunit',
@@ -60,6 +63,7 @@ local memoryUtilisation =
 local memorySaturation =
   graphPanel.new(
     'Memory Saturation (Major Page Faults)',
+    description='Rate of major memory page faults.',
     datasource='$datasource',
     span=6,
     format='rds',
@@ -71,6 +75,7 @@ local memorySaturation =
 local networkUtilisation =
   graphPanel.new(
     'Network Utilisation (Bytes Receive/Transmit)',
+    description='Network Utilisation (Bytes Receive/Transmit)',
     datasource='$datasource',
     span=6,
     format='Bps',
@@ -85,6 +90,7 @@ local networkUtilisation =
 local networkSaturation =
   graphPanel.new(
     'Network Saturation (Drops Receive/Transmit)',
+    description='Network Saturation (Drops Receive/Transmit)',
     datasource='$datasource',
     span=6,
     format='Bps',
@@ -99,6 +105,7 @@ local networkSaturation =
 local diskIOUtilisation =
   graphPanel.new(
     'Disk IO Utilisation',
+    description='Disk total IO seconds.',
     datasource='$datasource',
     span=6,
     format='percentunit',
@@ -110,6 +117,7 @@ local diskIOUtilisation =
 local diskIOSaturation =
   graphPanel.new(
     'Disk IO Saturation',
+    description='Disk saturation (weighted seconds spent, 1 second rate)',
     datasource='$datasource',
     span=6,
     format='percentunit',
@@ -121,6 +129,7 @@ local diskIOSaturation =
 local diskSpaceUtilisation =
   graphPanel.new(
     'Disk Space Utilisation',
+    description='Total disk utilisation percent',
     datasource='$datasource',
     span=12,
     format='percentunit',

--- a/docs/node-mixin/lib/prom-mixin.libsonnet
+++ b/docs/node-mixin/lib/prom-mixin.libsonnet
@@ -47,6 +47,7 @@ local table = grafana70.panel.table;
     local idleCPU =
       graphPanel.new(
         'CPU Usage',
+        description='Total CPU utilisation percent.',
         datasource='$datasource',
         span=6,
         format='percentunit',
@@ -69,6 +70,7 @@ local table = grafana70.panel.table;
     local systemLoad =
       graphPanel.new(
         'Load Average',
+        description='System load average over the previous 1, 5, and 15 minute ranges. A measurement of how many processes are waiting for CPU cycles. The maximum number is the number of CPU cores for the node.',
         datasource='$datasource',
         span=6,
         format='short',
@@ -83,6 +85,7 @@ local table = grafana70.panel.table;
     local memoryGraphPanelPrototype =
       graphPanel.new(
         'Memory Usage',
+        description='Memory usage by category, measured in bytes.',
         datasource='$datasource',
         span=9,
         format='bytes',
@@ -137,6 +140,7 @@ local table = grafana70.panel.table;
     local memoryGaugePanelPrototype =
       gaugePanel.new(
         title='Memory Usage',
+        description='Total memory utilisation by category, in bytes.',
         datasource='$datasource',
       )
       .addThresholdStep('rgba(50, 172, 45, 0.97)')
@@ -183,6 +187,7 @@ local table = grafana70.panel.table;
     local diskIO =
       graphPanel.new(
         'Disk I/O',
+        description='Disk read/writes in bytes, and total IO seconds.',
         datasource='$datasource',
         span=6,
         min=0,
@@ -224,6 +229,7 @@ local table = grafana70.panel.table;
     local diskSpaceUsage =
       table.new(
         title='Disk Space Usage',
+        description='Disk utilisation in percent, by mountpoint. Some duplication can occur if the same filesystem is mounted in multiple locations.',
         datasource='$datasource',
       )
       .setFieldConfig(unit='decbytes')


### PR DESCRIPTION
Add some lint exclusions.
Add UIDs to all dashboards.
Add units and descriptions to all panels which were missing them. Modify alerts descriptions and summaries as needed for linting.

Signed-off-by: Ryan J. Geyer <me@ryangeyer.com>