### PR TITLE
Remove forced uid regeneration

### DIFF
--- a/docs/node-mixin/dashboards/dashboards.libsonnet
+++ b/docs/node-mixin/dashboards/dashboards.libsonnet
@@ -1,3 +1,2 @@
 (import 'node.libsonnet') +
-(import 'use.libsonnet') +
-(import 'defaults.libsonnet')
+(import 'use.libsonnet')

--- a/docs/node-mixin/dashboards/defaults.libsonnet
+++ b/docs/node-mixin/dashboards/defaults.libsonnet
@@ -1,8 +1,0 @@
-{
-  local grafanaDashboards = super.grafanaDashboards,
-  grafanaDashboards::
-    {
-      [fname]: grafanaDashboards[fname] { uid: std.md5(fname) }
-      for fname in std.objectFields(grafanaDashboards)
-    },
-}


### PR DESCRIPTION
Instead, one can redefine grafanaDashboardIDs in _config:

```
    // Grafana dashboard IDs are necessary for stable links for dashboards
    grafanaDashboardIDs: {
      'node-rsrc-use.json': 'node-rsrc-use',
      'node-cluster-rsrc-use.json': 'node-cluster-rsrc-use',
      'node-multicluster-rsrc-use.json': 'node-multicluster-rsrc-use',
      'nodes.json': 'nodes',
      'nodes-darwin.json': 'nodes-darwin',
      'nodes-system.json': 'node-system',
      'nodes-memory.json': 'node-memory',
      'nodes-network.json': 'node-network',
      'nodes-disk.json': 'node-disk',
      'nodes-fleet.json': 'node-fleet',
    },
```

This is needed to make sure that dashboard links keep working. 