### PR TITLE
Split alerts into two groups

### DIFF
--- a/docs/node-mixin/alerts/alerts.libsonnet
+++ b/docs/node-mixin/alerts/alerts.libsonnet
@@ -2,7 +2,7 @@
   prometheusAlerts+:: {
     groups+: [
       {
-        name: 'node-exporter',
+        name: 'node-exporter-filesystem',
         rules: [
           {
             alert: 'NodeFilesystemSpaceFillingUp',
@@ -156,6 +156,11 @@
               description: 'Filesystem on {{ $labels.device }}, mounted on {{ $labels.mountpoint }}, at {{ $labels.instance }} has only {{ printf "%.2f" $value }}% available inodes left.',
             },
           },
+        ],
+      },
+      {
+        name: 'node-exporter',
+        rules: [
           {
             alert: 'NodeNetworkReceiveErrs',
             expr: |||


### PR DESCRIPTION
to stay under mimir's default limit of 20 alerts per group.