### PR TITLE
Fix logging race in systemd_linux.go

### DIFF
--- a/collector/systemd_linux.go
+++ b/collector/systemd_linux.go
@@ -199,7 +199,7 @@ func (c *systemdCollector) Update(ch chan<- prometheus.Metric) error {
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		begin = time.Now()
+		begin := time.Now()
 		c.collectUnitStatusMetrics(conn, ch, units)
 		c.logger.Debug("collectUnitStatusMetrics took", "duration_seconds", time.Since(begin).Seconds())
 	}()
@@ -208,7 +208,7 @@ func (c *systemdCollector) Update(ch chan<- prometheus.Metric) error {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			begin = time.Now()
+			begin := time.Now()
 			c.collectUnitStartTimeMetrics(conn, ch, units)
 			c.logger.Debug("collectUnitStartTimeMetrics took", "duration_seconds", time.Since(begin).Seconds())
 		}()
@@ -218,7 +218,7 @@ func (c *systemdCollector) Update(ch chan<- prometheus.Metric) error {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			begin = time.Now()
+			begin := time.Now()
 			c.collectUnitTasksMetrics(conn, ch, units)
 			c.logger.Debug("collectUnitTasksMetrics took", "duration_seconds", time.Since(begin).Seconds())
 		}()
@@ -228,7 +228,7 @@ func (c *systemdCollector) Update(ch chan<- prometheus.Metric) error {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			begin = time.Now()
+			begin := time.Now()
 			c.collectTimers(conn, ch, units)
 			c.logger.Debug("collectTimers took", "duration_seconds", time.Since(begin).Seconds())
 		}()
@@ -237,13 +237,13 @@ func (c *systemdCollector) Update(ch chan<- prometheus.Metric) error {
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		begin = time.Now()
+		begin := time.Now()
 		c.collectSockets(conn, ch, units)
 		c.logger.Debug("collectSockets took", "duration_seconds", time.Since(begin).Seconds())
 	}()
 
 	if systemdVersion >= minSystemdVersionSystemState {
-		begin = time.Now()
+		begin := time.Now()
 		err = c.collectSystemState(conn, ch)
 		c.logger.Debug("collectSystemState took", "duration_seconds", time.Since(begin).Seconds())
 	}


### PR DESCRIPTION
The same variable was used for timing every parallel operation.

If this is fixed then this exclusion from race tests can be removed: https://github.com/grafana/alloy/blob/8090b5c9896fed32de4015f8d7a38f4f30cb3578/internal/static/integrations/node_exporter/node_exporter_test.go#L1

Upstream: https://github.com/prometheus/node_exporter/pull/3364